### PR TITLE
Fix Youtube embedding in kolcykeln_enkel/kolcykeln_htm.ipynb

### DIFF
--- a/exercises/kolcykeln_enkel/kolcykeln_htm.ipynb
+++ b/exercises/kolcykeln_enkel/kolcykeln_htm.ipynb
@@ -1923,7 +1923,8 @@
           "base_uri": "https://localhost:8080/",
           "height": 597
         },
-        "outputId": "e83cd74a-9e3a-4c54-e4d2-befa9b8006db"
+        "outputId": "e83cd74a-9e3a-4c54-e4d2-befa9b8006db",
+        "cellView": "form"
       },
       "source": [
         "#@title Backgrundskod för youtube\n",
@@ -1934,7 +1935,7 @@
         "#Visa NASA video - \"A Year in the Life of Earth's CO2\":\n",
         "display(HTML(' <iframe width=\"970\" height=\"576\" src=\"https://www.youtube.com/embed/x1SgmFa0r04?si=5U0vy4jHix7A6cqM\" title=\"YouTube video player\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe> '))\n"
       ],
-      "execution_count": 6,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2653,8 +2654,7 @@
         "<br>\n",
         "\n",
         "###### Figure credits\n",
-        "<font size=\"0.7\">CO$_2$-icon made by Freepik from www.flaticon.com<br>Carbon Cycle figure created by Karolina Pantazatou (ICOS Carbon Portal), inspired by figure created by Peter Reid (ScottishCentre for CarbonStorage) https://www.icos-cp.eu/ <br>Map of ICOS station nertwork 2020 created by Karolina Pantazatou (ICOS Carbon Portal) https://www.icos-cp.eu/<br>Photos of ICOS Hyltemossa station, courtesy of Tobias Biermann tobias.biermann@cec.lu.se</font>\n",
-        ""
+        "<font size=\"0.7\">CO$_2$-icon made by Freepik from www.flaticon.com<br>Carbon Cycle figure created by Karolina Pantazatou (ICOS Carbon Portal), inspired by figure created by Peter Reid (ScottishCentre for CarbonStorage) https://www.icos-cp.eu/ <br>Map of ICOS station nertwork 2020 created by Karolina Pantazatou (ICOS Carbon Portal) https://www.icos-cp.eu/<br>Photos of ICOS Hyltemossa station, courtesy of Tobias Biermann tobias.biermann@cec.lu.se</font>\n"
       ]
     }
   ]

--- a/exercises/kolcykeln_enkel/kolcykeln_htm.ipynb
+++ b/exercises/kolcykeln_enkel/kolcykeln_htm.ipynb
@@ -3,9 +3,8 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "name": "Copy of Copy of kolcykeln_htm.ipynb",
-      "provenance": [],
-      "include_colab_link": true
+      "name": "kolcykeln_htm.ipynb",
+      "provenance": []
     },
     "kernelspec": {
       "name": "python3",
@@ -1759,16 +1758,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/lunduniversity/schoolprog-satellite/blob/master/exercises/kolcykeln_enkel/kolcykeln_htm.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "R2hDRoLniXjz"
       },
       "source": [
@@ -1801,7 +1790,7 @@
         "<br>\n",
         "\n",
         "\n",
-        "## Gör så här \n",
+        "## Gör så här\n",
         "\n",
         "Detta är in interaktiv övning som använder sig av programkod. För att köra övningen, börja med att:\n",
         "-  klicka på **Runtime** (alt. Körning) i menyn och sedan **Restart and run all...** (alt. Starta om och kör alla).\n",
@@ -1816,11 +1805,11 @@
         "\n",
         "**Att köra kod**\n",
         "\n",
-        "För att köra kod som finns i en enstaka kodcell, klickar du först på cellen. Då blir den \"aktiv\" och du ser en liten pil i vänstra övre hörnet. Tryck på pilen så körs koden. \n",
+        "För att köra kod som finns i en enstaka kodcell, klickar du först på cellen. Då blir den \"aktiv\" och du ser en liten pil i vänstra övre hörnet. Tryck på pilen så körs koden.\n",
         "<br>\n",
         "<img src=\"https://github.com/lunduniversity/schoolprog-satellite/blob/master/exercises/kolcykeln/images/run.PNG?raw=1\" width=\"30\" align=\"center\">\n",
         "\n",
-        "När du klickar utanför kodcellen visas ett tal inom hakparenteser i stället för pilen, t.ex. `[9]`. Siffrorna visar i vilken ordning olika kodceller har körts. \n",
+        "När du klickar utanför kodcellen visas ett tal inom hakparenteser i stället för pilen, t.ex. `[9]`. Siffrorna visar i vilken ordning olika kodceller har körts.\n",
         "\n",
         "\n",
         "<br>\n",
@@ -1870,7 +1859,7 @@
         "<br>\n",
         "<br>\n",
         "\n",
-        "## 1. Vad är Koldioxid (CO$_2$) \n",
+        "## 1. Vad är Koldioxid (CO$_2$)\n",
         "\n",
         "Koldioxid är en gas som är lukt- och färglös vid normala temperaturer. Den bildas i förbränningsprocesser när kolföreningar reagerar med syre.\n",
         "\n",
@@ -1923,53 +1912,41 @@
       },
       "source": [
         "## 3. Ett år i Koldioxidens liv på Jorden (NASA)\n",
-        "Klicka på videon nedan för att spela.. "
+        "Klicka på videon nedan för att spela.."
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "PO8EqWpbGl6Z",
-        "cellView": "form",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 597
         },
-        "outputId": "76867dd1-ab8c-413b-be44-86aa89a39a9c"
+        "outputId": "e83cd74a-9e3a-4c54-e4d2-befa9b8006db"
       },
       "source": [
         "#@title Backgrundskod för youtube\n",
         "\n",
         "#Importera modul för att spela en youtube video:\n",
-        "from IPython.display import YouTubeVideo\n",
+        "from IPython.display import display, HTML\n",
         "\n",
         "#Visa NASA video - \"A Year in the Life of Earth's CO2\":\n",
-        "display(YouTubeVideo('x1SgmFa0r04', width=970, height=576))\n"
+        "display(HTML(' <iframe width=\"970\" height=\"576\" src=\"https://www.youtube.com/embed/x1SgmFa0r04?si=5U0vy4jHix7A6cqM\" title=\"YouTube video player\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe> '))\n"
       ],
-      "execution_count": null,
+      "execution_count": 6,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
-            "text/html": [
-              "\n",
-              "        <iframe\n",
-              "            width=\"970\"\n",
-              "            height=\"576\"\n",
-              "            src=\"https://www.youtube.com/embed/x1SgmFa0r04\"\n",
-              "            frameborder=\"0\"\n",
-              "            allowfullscreen\n",
-              "        ></iframe>\n",
-              "        "
-            ],
             "text/plain": [
-              "<IPython.lib.display.YouTubeVideo at 0x7fcbba33a850>"
+              "<IPython.core.display.HTML object>"
             ],
-            "image/jpeg": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEABALDA4MChAODQ4SERATGCgaGBYWGDEjJR0oOjM9PDkzODdASFxOQERXRTc4UG1RV19iZ2hnPk1xeXBkeFxlZ2MBERISGBUYLxoaL2NCOEJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY//AABEIAWgB4AMBIgACEQEDEQH/xAAbAAACAwEBAQAAAAAAAAAAAAAABAECAwUGB//EAEgQAAEDAgMEBQkGBAYBAgcAAAEAAgMEERIhMQUTQVEiUmFxkQYUFTKBkqHR0hYXI0JTVGKxwfAzQ2NyguHCRLIHJCU0c4Oi/8QAGgEBAAMBAQEAAAAAAAAAAAAAAAECAwQFBv/EACoRAAICAQMEAwACAgMBAAAAAAABAhEDEiExBBNBURQiUmFxBTIjQoGh/9oADAMBAAIRAxEAPwD5+hCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhP+iKjrR+J+SPRFR1o/E/JU1x9nR8XN+WIIT/oio60fifkj0RUdaPxPyTXH2Pi5vyxBCf8ARFR1o/E/JHomo60fifkmuPsfFzfliCE/6Jn68fifkj0TP14vE/JTrj7I+Nl/IghP+iZ+vF4n5KPRU/Xi8T8k1x9j42X8iKE96Kn68Xifkj0VP14vE/JNcfY+Nl/IihPeip+vF4n5I9FT9eLxPyTXH2Pj5fyIoT3oqfrxeJ+SPRU/Xi8T8k1x9j42X8iKE96Kn68Xifkp9Ez9eLxPyTXH2PjZfyIIT/omfrx+J+SPRM/Wj8T8k1x9j42b8iCE/wCiajrR+J+Sj0VUdaPxPyUa4+x8bL+RFCe9FT9aPxPyR6Kn60fifkp1x9j42X8iKE96Kn60fifkj0XP1o/E/JNcfZHx8v5EUJ70XP1o/E/JR6Mm60fifkmuI7GT0JITvoybrR+J+SPRk3Wj8T8k1IdjJ6EkJ30ZN1o/E/JHoybrR+J+SakOxk9CSE76Mm60fifkj0ZN1o/E/JNSHYyehJCd9GTdePxPyR6Lm68fifkmuI7GT0JITvoybrR+J+SPRk3Wj8T8k1xHYyehJCd9FzdePxPyR6Mm68fifkmuI7GT0JITvoybrx+J+SPRc3Xj8T8k1xHYyehJCd9Fz9aPxPyR6Ln60fifkmuPsdjJ+RJCd9Fz9aPxPyR6Ln60fifkmuPsdjJ+RJCd9Fz9aPxPyR6Ln60fifkmuPsfHy/kSQnfRc/Wj8T8kei5+tH4n5Jrj7Hx8v5EkJ30XP1o/E/JHoufrx+J+Sa4+x2MnoSQnfRc/Wj8T8kei5+vH4n5Jrj7HYyehJCd9Fz9aPxPyU+i5+tH4n5Jrj7Hx8v5EUJ70VP1o/E/JHoqfrR+J+Sa4+yfjZfyIoT/AKJqOtH4n5I9EVHWj8T8lGuPsn42b8s6+IoxlRfsQuU91N+ycZRjKgqpU0irlJeS+JVJVUe1TRm5sMRUi5VblGamimovh7UYSgKwzVWbRjGXgphKMK1wqpsNUsl44ozsiyknsVblWVmMtKBRdTiythCix4KyMn/AZ8lbdv6rvBSL2zJQZDawtbuRt+CyivJUtcOBRZxV29L81vYnqWlhkID6hjb87BUlPSty8cd7+BDC5WDXleqpNj0rgLytf4FdFmxaQWvGw+xcsurivBWWXFDls8O2KR2gJWjaWZw9Ur3bNmUkebYW37lZ8HRsIgsn1fpELrIeEeDNJKNQPFZvhc0dK3ivX1NI46Qsv3Lh11DNYuMYA7AtIZtXJ1QyRmcg2CjJS+7TYjxCzxFdaRlOVOiUKqFajLUWugKArttxUPYvFORAbdW3aZiFMfWcQONz/wBKLxXNnC3C981nqZ0xxwMN2FO7HJbDATq0e1Xa1h4jxVXJmnbgLYByU4OxPNZEW54rqj4wBdunaFXuBKPoUwdirh7EwTnYgIDRxF1bUT20L27FCbEbT+R3gh0DRq0hNaK6BRGSYMI4EH2rN0RbqFZSRHbaM8kZclbB2qWtIOl1NldL9GeSLjktMAPCytuD+U3S0NEjJFldzMHrZd6i7e1LGlLkopsVbLhdFnJZGlFbFRnyVwwniEFh5pY0MpnyRc8lbCVFnKStNEYipxlRc8kYihGr+ScRRjKi6kHsSidf8gHX0bdaCCd2kR8F14oaVmTDY8yrPGE5EFc7zekTv7OQKOpOkapJTzR+u0t7wu02V8ebQHJqGVtWyzmtcORCjvSXgrJUrZ5U4goxFegqqSkLukwxkcjkkaqJgaGRsaHc8NitY5ovwVUHLhnOxFRiWroXsdhcRfkqGM3totrRRxmiMQ5LRr4+IcqGF4GihrCTYC6fUJ5Ivg23kdssQPesyb6XWjYm3s42PJMthZh5d5WbkkdCjOfIm1j3aBXbAPzOA+K0le1mWRKXMrzxU7srJQhs92N4aeMZtc49psovT5Ws09maTdci97qilY78lHnriI7KY3W/ELgOaXdb8puskBXUK8mcszl4L3I4KMSuGuIzFwr7lpPRvfkQobXklQm+DSjrpKaQOY8gcl6mh20yUtYS7FyIXAo9kSTEF3Qb2r1FBsanpy2QdM24rhzyxv8AspmnjjGsm7OjHI57QcNh2rQusoOQzyCUfXU7HFoxPPYFhGGNf7M8d9yb/wCOI1k7iVy66KTplr7Adl1d1XLM78P8McuKWnkkJwyyPIPbkqur+p14ITi/szh10V3/AIlvYUkWU98wV35aSOU2DWntXKqtn7p2Trdi6seRcWexCcZKnyLBlKp3NOdHkKppH8CFHmcvZ4ra17Lf+F/NGn1Xgo82aPzBLvjkZqoEjusVNSfDGpLlG24Vd3wAutIZBHZzgH9l1Y1pLjZuEcgo+xpa9Gfm7+qVQtI4FMmdhHSxErMyAW6IUJskxuQpEpGVlo5zCPVsexZjM2sr8kPbySJMRzTEcxBAY2w58VmISdGk+xW3R0Az7SqumSk/ISGVx9e/tQ1sozN7KvTJw3J7AtoaaaV+Fgff/coe3JFpEMjxjMW7wpMDeZC6MewKp3rPcP8AktvQFUNJvFZPLH2ZfIx/o4T2OYdAUNEtrhht3Lqy7HrGPGJ8ZCzc+WmFntFlfuJrbcusil/qxIQSPF8NlVzHxOuXBNuqhIw527VyqiQuOpzV4JydCc9KtkTuxuJJJKyxEcUAIItqulJJUefKTb1FhIRxV2te4XGixy5rXHijwhwy4JJei+ObfLL2Ida4Wm7fa6ziikLhhF7mwXVZC10X4nRtqFzzkonVB2rZy7EHVSGuJ4JyWCBty17nf8UthbfMkd4RSTLoh0eEXP8ANZuAWxYXMu03srbpwju4iyJlmr2FSO1AIGquS0XsM1rTCKSRrXtyOpV7pGNK9jWmdhfZ5y4rqwiN+pXFgnbhtI2/aNUyypgZo1x7CubJBsma1q0dGqMTIS4W7EhBVYH4sXS4dixqKl05z0GgCWe/LC3JIY9qZMYaIfY7c+0oZQGxtLZesc7LGaSSRuIgho43tdJUEBL8ZF7aBPyse5hHjyCq1GLpFYpRpCzzQujLjHIHji3MfzSDnML7jNMMH4zmcCCFzwbOXTjiRllof9nQjLtGtxXyU7h8RvhIeRkDl7VlSSESAXz4XXZjhknYxrpQzlh1WWR6GXlkVJnAc8seS71uKgPc7iumdlvbI6R7d6wZ3HFLilxOc5sZaOQWiyRaKRi29nsKNDXPs51gnTTsZHdgLsllJSPDS9jThHNVY+eMZA+CN6uGWitL3RjIzNZlhTJdJIbluagxy64cldTaKyxRluL4SrsaBqFvDA+Y9CMm2tl0ItnRvsCXNdycqzzJclVijF3ZzQHXAGYXQY3choe0XOYKc9FYCC3gq1UDnsaQLFuRCwlkUuDVTi9kzeKYlgwp6Opkab4teAXPpG7tpMg0W4qXu0aMPBcslucWWO9JHQNW2SMh5sl97CAbZrA1Idk+wHYoLC9uKJ1wqqJgsfvYYbNxZHlzUSOdIMJGqwpZAZMElwWraqbwZ0SQlUydKjKizIwOQWM8MTjmAubLVVDHFuVwr01WXm0tgVp22tzp7M19rLy0rG6ZpSYiEG/guhIejx7bK8FLE+LHKLntUqdclo5dKuR52aUyZK8kYEbQyMONrk2uujVCCN+FsdyVVrGPcAXWYMzhC6O5tsjoUrVnIwPccgmIqSe4O7JC6wdT4sIppDbmwqHkvyibh7gVDzN+DNSp2kISU4wdLouUNo3vLcQI7U+aHEwGSU4jwwreOFsLRd5sNcis+7XBZ5V4EpaAC1tVeOkjhYXPzcOy+a3LzMfwwcHXdkPYh9TT0jBieJH8uCjVPgqpzoItkyVH4lVNuYvysZmT/QKx2ds+N9mlzj/E5c2o2nPUmzSQ3gApjjdG/FI83tfCNVppn5dCOOT3chl+zoHH8OwW8MtHs78wLxwXPlqzYhgv7Fk3Z00v4jsgeCaLX3exM4uqZ23+UTiPwmZJSbb1Q7V1uwJCOlq5LsjgflxOS2i2VUA3lZGP+SLHijyUUMMdkgdtWWS/TsVSSYyNu6QHsKbioQ6SzoGuZbgTcKPRjMeExSxt56qdUEaqcUcqR3QOH4JdzS4Dmu7JsdzW44XGQciLJIFrCWva24yOIZrWGVf9SJKOXhnOAfoArNpppDkwkrssrKaNg3lLHl1QFMO04GOdu2Bl+y6s801xEweLwzl+jJRm8exZy0skeQabdgT1VXSOcSy5HMhYNrCbiUNd38FMcmR7sv2saVNUKsc+F4OYsV1HbQBiBAHtXPnkDuldt+Q1S+8PBaPE8u7Rn3I4m1djb66RzjbIKG1F83C6UAe82WhpyAMRv2XUvHBbMQy5XujYSPLrsNu5WbOCSH37gssLWWtcZKtvFUpM1U5JjEj2ubZjA1Up3WkLXHuVQeBVH3vdQl4LSlxJEtNlpG1z9MhzVgyxu0371fE7JvHgAqt+jSEHHllSLZalN7P2a+qdidcM4nmm9n7Ic872pGFvVK6M87Im7uIAALnnm/6xMsma3phyZuZDStDGgEhcraNdf8OPIcbKKupdmATc6lcx7rlTixeWFHRHU+SDIb3usir4b8VWy7o7HNk1S5JY4tcCNQuxRVdQ8N3ZNsVnAZlcYL0uxaYCjEp6V7kAcOa5+paUbZMZaY7jZJFPprw5peONzQ9rmOtqmBPvBhZZrGq8cjnsLiLNOQvxXn20TqcVwYQwNJxSjLkn4qKCRvq2HJWhpxL69imMLI24RdV+039TkzdUl5M2UNLnhiBtqbZKJKenb6sMZ9i1MgY0k2FlgZ2k3IJXVhxO91Z5mXqZviTIaGMJDYWtPYMlQiMu6UfgrRPZvekOieBUy1dMypbSY343C5DRe3eujLDFF1pMsU8+R/WTbLbloYSwkdiSlbe5xFdIsLYnCM4hbK65e/jlila7oyDLPVec19vrwer0zyNWykkQJc1puSLrKNjXR3xEHRUD5N2xzSC5mXespXY7EAh/FaKLPQUW9rNNJcOoPEHRWhmwS3B0NisHXY218zqVamYZHAAZK1bF9Krc6MgayVk7R0XZFG0HYIg4nKy0qGjzQtHAZLKrYZ6IWzyWK5Rxxacot/0cYFuEue431WNnYsTTcd6l8TnTFhKgRysdgjOfYu1Ueshune/GMn8szYK1VO1jHMJcXvFhh0CXNFL6z5Mwrt372GJxu3sAus2o3Zk4xbtGcTZJXNik4DLNd1tG6CktFCHEN1xWv2rhzSOje10WI4RmHDVWFTLVyh8tw51m2F8h2cklFyVmeSMptaeDo08zmuwztaCTo3guk2njeGkNYW8y0X/kuZSwuL8T7P7TwXQpGhj3WJF+C5p7cHLn23XIwGxxsJcBYcmgLkV20YmXZHGXu/i0W1fPj6ADgQbZHVIT0WOMuB6XC4U44q7kTgxpfbIzmz1k07rGSw5NWD4i3pOdiHenIaORsgJhL+zRMVNFBiJxuj55XDe8rtU4xdI7G48MTZKwNvG0AhaQPjLLyOtc5pKRhhlLTmOY4qT6traq+lMuslo6NLXsbUBrI2lpORIXZgmZObgDLI2Fl5mkpJZ5Ghowi+pXrKSCOIEgZ2zyuuXqFGPBy5ZJRuXJbcvcDYHPQaJfzJ28xEOvfiukJcGV9VcY3ZjLvWCUqvg8z5ji6QmwOit0SO1S7W7gCOYTuF+jrexZywngLdoKzewjmUnbVGJDHNsD7FzqyljkuHiw5rWsimjGIEkDgubPI4N4gnmVpji+UzvwYnymJVbYmAtjA9qUYy51stiwvfcuCtKGMHrdKy74ulR6GleRaaVwODF0QFkZ3SCzm4gG4RlZW3O+fhYcuJPEpqamZSsjzDnOGlswumORY/7OLJB5Xvwc9sRJuRlxWjY8Z5BMHMi4A/qs32AvwJUPK5MuunjBX4JxNb6gv2qzJH36EIJ5kXW1EIsQxkDvXpqKClqIAYmm2l9FzZMih4Jy5e1FN8fweTkc93rRgHsCyJvwzXrqnYrH+pdcKs2e6B5GEpDPGWwhOOX/AFZzdEHNaFudii3MZLazTQ+DrRbBff8AHnDRyaLp6KCmox+EzpcXHMpsguOvsUtiaNALrzZZZS5Z58szf+zMHPleMgQEnLE7Fd110gGvvc3KykjI0071EZUWhlp1wefrIXNKQc0gr0c8bnNsWi3cuXNRm5N12YsvhnbtkX8nOKABxTDqZ7eF1iW8DkulTT4MXilyRomqeukjZu8ZDBmAOaVwFXjhL3WsklGS3CU06SO3DUiRwYxota7iNLrrQgTAN4DkuNSsELC08Rou5stpLMRABOi8vNS4K9S9MbHoW2GWgViAVqWhjcuKwOozyWUZUuTxJK2JzQve/WzVlnI9zYm4WtHrO4p/GHusAD2KrhLgOJrWt0Atqu2PWaY8Gfxbe7MY4W3AIDiplooZnB74w1/FwNibc1heeBxaG7pvAWyS0lZLjs8/JZSyzycs7sXSODvGzrSTiKMBjhkuPXt3z8YjsbesFdspdqQtGDEbEXWS+rs6sUO1uc+GmfYlhJHEKzoxHmbnv4rpiENzF2rJ0cZNybq2uzXv2xBkElS4YhZvJdGGFkQs32nmrRhzzhjaFuKV2rzdRJtmGXPezdClTKAwhaUuLdlp04Kamla5pCzgY+PIvuq7NEfWWOkLVlK3FiAsUrE1zH9BgJ5ldkDes6Q71iImtk5qyntRtjztLSyrqdkjAZXFp4hpQ6hgc3DnnxTLgAQSNFJuRwsqamVU5eGc92zImXcZXDuVBAyL/DJLjxJXQLXd4WjI3EjhbsVu4/Jr3Wlu7OWC+GTpBw707C9gcHXzW1SGTGzhm1YMjay41UNqSKyqa3NWPYJ3FwBusqmdkZLsAJ4KrrDQpWaN9Q6zXWzRRTe5EMW9stIS9wLbtK1hi3w/EYNLEW1TDKfBHzcrRNIdd3gocttiZTVfU50mww6Xou6JN9Mh2JiPY8LR6oJH5iurGQ4CyuMja1k7s2uTml1mRbNnOioxHqB36JqO17Mz7AMls9ocBYK0TA13BWi1Vvk5MueeR0+DIRXcSHDFyKtvMI7VeePADKzEXDUa/BLtO8zILTyW3dWRXIx7Eoq4boHzvCqKgHIg96h7H8WqrYxcl5wgcSrrQlwY1Jss6RuLMm3akK2kjw7xhJHIJ58ZBwgh3Ky89UbTqhWvY2MMaD6r/wAoHFZqLm/r4PS6JZIy2YvOWxuc65w87Lny4i0PNziNrpyv2gapoY44+3QBY0tKyTMk5cRndd2NKEdUj1JSlkelF4oAyAEnNwyVHYYXDEcTrahMyNcWiNoOQzWTqKcjEIyVRSt7s6HFRiqFXuu/N1hxIzVbFzsLLkfzXTp9g1MwxyWhZ/FmfBdqg2VT0oxMBe4fnf8A0VnljFbHnZuphGVSf/iOPs7Y09Q4PlvHH26leohdDTRtiZYBotZZySYW4WeKxiaA0l7iSuDJkczFuWZXPZejoNlBORWFTTNmGYuUtYah7rqjqqSMhtySVlTbtEQwuL+jFKnYZmJcwlpSJ2HWg26J9q9BHNIRdxsFYyA8S4rVZpx2N/kZo7MyiaeOa0f0Y3YVUX00KsACLH1RqVlyzkk97YtSwSGUv0anHRkjMJR9eGkix7FEVa6+ei6n0mRrUc0+uUpGkkJGiUkjA/KuljbKLg5rJ8YdlZc+8XTOzD1FnLcxnVS8kDCfUHguq6lub6KW07G5kt9q0UvR2/KhHycmOlB/Jf2LdtKRoAO4LptdCziHHuUGdl8owr1kl4Oaf+SinQrT0TnOGIZLt0sQy/hSUb3PcMrBPU9wSufKmuTmn1MszNpwTHkbG6WNwc1etdKYfwXNa4HV2hSsdXiq9yYnMFvXI6JPYqabVomOKTjaNWscXgtGfYtJN64gtdchD6plM9kT2npauBthWjYmx3OXS1PEqVF8kOWhJtC8hmc+zoyQRok5aTjhv2LoSPvk24HNYvc7DYOzWig/dFY9U4v6o5r4nDVioG2PqvHcumAeIUl0bdbKaldLc3XXKvshEOccg15PamYaR783mw5LVr8fqgW5rRpI1zV1hk+TnydbtUUWDWwizbBasNxqlyxxNymIRcWWrcIRpHF9pO2Q9gkFiPalpKXDm03T9gFR1lwykm9jqhKUREscLduasA0Z2zV53pQvc4WZpfMpydmNOXJeV7dNVmA4jJashJOl1tHTOfpkEs21RijGJgabuJPYtnzNjjuVY0sg0z7VzNqyv3u5aLYeKJanREEssqsh02OoOFy1aQTmudHG9ulweachvbMElayVcHXOCXBo9oIAVWNDbhug071JcSLAZreGndbEQqXSMpS0rcmB7jYE963sCO1UjjLTmtmtafzeCpVvY4p5IpgxuYwm1tVEkpBs03PNanCG5nCEtUTxRi11vigr33ZxZZuXBVtQ/QeKajd0QXarn0kwnnJB6DeC6JczvWmeEk6UaM8Uo8tlRIQSTkFhNIXgNjkDTfnqtJiGktwkC17rNtBGyFgOt7rmitz04yhFamMUzjubTEEjjzSW0op5yyGnya7Nx4BWr6pkTRC05DVZUdU58waNDouqPTT09w4vlxjl2RiwGgpnl8gJAOvHvXE2nVPqnWjtgvm3JdXaMpmrDSySZOvdgGlhz9qNlUhwASRC4yuTclINQWt8nsw2jrlyeYZE+4uwkX5LoxXjH4bDYZ3OQXqG0sUbBjY0O7Ap3EBsQxpt2K0uoc1/rsZLrMUHRz6GmdJA17mBrnZ2unCyOIAubcjS6u6VrGkDVKucZDqqwxOb1S4PO6jq3J1FlnSF+dymW23NreCWDQ7TgrGcRusX3C2ywc46YnHjlplqZZrSc3NI7Vg84LttZMxzQuPRdY8irPha83sL9i43Fxf2R6WPqIt/wLMsWkjgrwtbhuRe6pJC6MnDdawOa9vR9o5Kr4OibWm0UkjIOuSyu4eqt5Ab9iph6WhUJkRltuWfUxszNknUVzpeizIJR2IjNQ0Z5ar3sXSY4bnzs885bF7E5nVXbdBbpc5rWOK2ZNwtJTSW5VRdkseWrdtQ8BYAi9rhXuBrmuScYvlG0W15LOe5+t1m9jrX4LRskbTdAeHYidCoTceETs+WUiju7NdBlLCWgA2cUkC0Z3utGVAaRY29qrk1S4EaRthLH4U3C9rLi/SS7amJxBfa44qjqmIXc1wPKy4543Lwbxml5GS8uk6TcuC3Ijc4PFgRwK43njg6+JR51JjxNfZSujn5Lvql4Ox5tE928lYHSHRxGg5Kzn4L9K/FIsry4DFr2LJ1S/eEWuqxwzT3E82pGznue/sWNZVR0tnyXIHABXjxG5Nu5KTxzVbt222DELg8VXJWqnwb9JBN3Lgd3jamnEtOd4w8uCyZAXHpk9q2o8NJC6FjSQ25xLOWolLgRGAeJ5rfBkdaYnN1OOKntwPRU7A0Z2WjIWt1zXOZVaOvkOB4LdtZcqMkMsjOMoIbNr5NVdM2rnurJBJfFktW7SaPXF1R9JkLLNEb3oVHyAhYnaMFrgXS0u2IWeq0KsejzSfBfvwQw6J0vGw5raJkTMLMslw5tvBws0EFKx7UcZLkZ87rvxf47zkInnySVR2PUyzwwC7rXOgSfpLHJhZouXv2yZyOw9q1ZLSQD/EuV0R6TFj8Wcssk5cs7MU5fqVhXQ45WuZFjvxusqeoifYtNgU1LOY2WhbvCeN8lwdVhUd0dXR5ZKYjJEWgh9o+VkrTVkbZjDK4uAt07WCtNT1UjjI8kvOTQdAkodlV2+Ej5A1pdmeNlzRimt2e6pY9L1SO6DCM2gu7gpmddnBvIXWAmhp2dEkkGywmrHHEHwtLDkCSph0eWW9HlS6rGpex+ne1zLFwNhwWLnyMJDQbc0t54xrOjYEjglpq51gBddeDpZpvUjlzZYzlcBiplIwh7yS7hdcqvrS15jaLntVZaguDpT3BJ2MhDibleriwKBzLd78Hb2Q60JLtSV14zlmuTS2YwALYzPaOi5c+aGuToqpeTpyDHCRa/ZxVHVO4bZ+bhw1suadoPZ+axSs1bjYWkEkm+K65l0LlPVLg6PlNY9CN5HNkeXOzJzWlPgYb4s+xIslBba5UtqGg4b5ruliemkcilvY9WbONbUNnhdu5LZuByukIX1FPUObMHNewixbnfuC6FLUOBwEEXF7ph9UWkNcGuI0Ns15k8E09Pg9nB/kdMNM1ZNTO++ENztmSkxM9pxNOatUTvkNshdZWa1pu7Ps0XThxqEUjzMktUrLPmLiXHiUCTgFDHsbk7MLMnktdKZnbNg9wKGYSXY23J0WbX5hab1vJZSi+C6ZnMwMbdViqnjK5KyqZi6wVWLqjD6fYycvtsPsrC3UXC1wxzWfEcDuNjZct8mHIaoY51rhxC58nRxmrWxvi6qeJ7HYa0N9d4z7VYmMD1r9y45c46uKjE7mVgv8AHr2ay62T8C7pgBfitI5sIJNrrmh5cbkoEudrr2nBNUcmhnUimxm60M/AJCKcDI2Wzc3LKWJN2yltDkYxOVpD7FhFKWyAOaryuc7QLncHqLp7Fge1BktrklXuc0ZvsFVkjTmX39q17Se5XUM7wkquLNUDhrdTvm3sp01wiLbBziTbgpDiFRxN+xSSrVsVskOJ1V43hrukqA2UOGJQ0nsyU6HWuba4N1sxwsuY0kLeKXgVzZOn9Gscg6HneNDSblMMO7JOrjmUg2TA4Oucj8FrLUtFjwK4s3TuUkktjohl0xY443b/ALkvPKLWDrG1lhLXBkZF7ZZFcqWqdIThOSv0/StbyEpPJtEdfJu9Be+q1ZU2ZwuFyN44aG4CGvkAuPBd+iLKdmSG6isOMG+vBYmrDvVNu9LOBBsQqWz0zWy0k9hDM1Q4tzKVEmI2Kzc9xNipYbHNapFlHSjbBcXCyc6x1W7XZLIsBeVFFoT9gJHniVoMVll6pQJSFm9RqqGWySMthcRZNRVNST65KQEwTEMwBuM1RtkaIvwOCoqwcRd7CsZaqodYF+XJPQgPAbIzDdVfQXJLXC1rhZ2O3H0c9z3Ft3vvbS6htaAMD72tl2Km0SIw1rWlp1PalGOue9WTsOEWh10zRmHZc1kKoPJB9UpOdzrDPJYhxHFbRXspoTR1JpGFgDPas2uDSCDkueHnmrmQlq0op2q2Os2ssbXUyVZOQK4uIjQqRK/rFV0xKdg6Tp7ZkrM1LSQLpAvLtSoup2LrCjqectHFQ+Vjtc1zQVozvTYdlI69BWuY7A4lzRzV63aEhl6LQ0Bc+JpBviAW8kYmb0pWtA8Vi1G7L9pWXFWbAucQTyWclVYBrSSVlLTtDfw5A48rpa7gUXJPaidDfhrAXON1m6vb0QCe0pB7i7UqhKuqM+xE6cVXd2T/AGJjfFrLuOZ0XFjfgcDa9s804+vEtg5gAHJQ68opPD6GTLicEyxww3XOieHO6JuCm2PBFr2srSSaOeUdLLPN32C1Y7CM9ErMSwYm271i6qeRY/BNFohRb3R0N4xQZbLmmVxzuoe9wIddO0i2li+Mi4VnCzRnmVgQ4m97o6Tjmtjr0mgc5pvdWbUvZJive6zDSO1VIzQUmdE7SLR0RnzKzO1JCLOski0oDearoXor24G76uSQKgkfe7r2VWiy0aBZWJqK4Q1BICwAO8VZ8jMNnZpC9jcKrib5lRRn2k3Z046xuGw+KuapvNci9ldhxHVRoRDwo6zJ2nQq4f2rkFxBWjZnZZpoKPD6OoH5q4cOOS5zJlpvbqjgZ6WjoNffJS8lugBY7nlYrnslLXXunY57dqzlCibrkUqmPElnXHEB2SyYCDYrpy0nnTC9mRGduSTZGTe/Rcw2seKo3Z24ZJqiYo8Z5EpiOlLiAy9+Kq1wjtlfvW8dQ5jsYycOKhPY0mm+DOqonxsxkXtxC5b5LDtXUqKl9QzgBpYaLmTR4tB4JCT21ERi0LF2agSWKHRuasTkV1JphoYExJyyVsRKwYDzU3sr0ZsYvdQY7pcOPBWDyOKihv4NDG4KWOLcwVWOaxs7Rbsax7wL2BVWiVNrkYbXyREFziSAom2jLKMjYclpPSAglgy1BJS5pHAXLguVxsuskWYzVD6g3ldcjisw1wF79q183IPS+CgsLOzLiml+C2pGUhuOapu7i7VJBK2YGtjva61TcY7j+hYtIKLZIccyourKwFlNlF0XTkAQoU3UXTdAkKwNiqKVPIN2yk6DNSSSNTfksY34HX1V3StJu1pCikCzo3ttiFrqtrHitBUE5uAJQyRpvibmdFNENk08WNxLmYmDXO1lVzBiIDbJpgBZxH9VBsclR1ZGoTdHbRZEFP7oHkexVNO0Am2SbUTYpHM6PTRMR1pv0wLJeSPC48lQiy1XFlJQjLk6XnDJG2BWbxlcJEG2i0NQ7AW81Jl2q4LskJJHBSXFrrXuOSwa8g58FfGCb3sVYs47lQ1WDDzUByMaFty2EjQqHC+oz5hGNRjQggG2q0uHcVmSCqoTVlzkdVAcVQnNTiUWWonGQVBddQoUikF1ZjsLlFlBCEjWRCi3JYMfhWhlAF+KGTi0bMaVc5JTevPFTidzQq4MaBPNMxk4RYrmiRw4pmCokdK0OHR7FDRWWOzt0s1oBmQc7pJ84xPew+sVo6YsYGgAX0PtS7wXDJcunezTDGtyN68m4sVcTuPrNJ7FSK7DZytJYOye0EqdKJeSSdM3DotcrnhfRJzz52bayzlYRmHeCWkdJofFaLGXWRM0klyzslnEEqSSQqKXGi1gHEILiVChaIiiwcrh3NZhSFJDRe11Zr3MKoi5QqdmlqhLTlrtQVqwA3uuRTzbt3YdU8ZRpdc840yFBVsO+bPkYXRtvZcytG7c0HiLrq0FS9hBaRa+ZPBcvbE8c9c7ALBuSiCblRSNp0xLeK75Q6PIgdiyuBkQrDCOC3lGzZOjMtOpULVzr5LKymgmF0XRa3FTiHAKKJsLE6KCCFOJyi7lNIWwui6nFzAKAW8lGkWSHKbqMjoiyaULNG9IiyaDberolIzhcCU0XWbcaLOaolOy97BQXKjXB+XFSRqCQsixZhK1JLPbwWULgx1yLq73BwuEstSMpXMcLW1SbxYkLckZ8bJeQ5q8Jb0UcSqCoui61e5BKlQCrXsrIhlLlFyhCWCLouoQobBN1IcQqoSwWuCoUIRsFroxKFCsgWxKQVRF0FGhAKqoDlJUNEEs1Whbfis26q91JD5JwhNUD2sqQXYdDbFok8SmMGSVjOsQEfBFHWnmYMAba1rm3bml95c3usZC4yOAzANku+Qi7R/NcyTbpF9NIadU7vt71m6XFmlcR5qMa3jBIq1Y0Hng4q28dxsUpjKkSFWpEaWbOAOYyWLhYqcd0A3yKholbFUIQoWxcLouhCtZFBcqcSiyNEI2LXWvnLvzC/aMisWnPNWLeLTcKrp7MmvQxFWOaeY7VpOxswbLGLXycO1IW5LaCUtJadCoquBsyxZlmFm5pTLnMwg39iweRdE7D2M8+Kg3U3ujRXohMrZSpGZV3RkNxcFFklFBKlVKsRQXUEqEKLJom6sHqilQKNQ+zgSLhMmVmABpt3pFWBRrUODWQnEbCwVWuKjEVF+ahKhszaNxvY6Jpobb1rZJDFbQoDyNCVDgmV+wzO6Nps0G5Fz2JQkn2LWwkzc4rMtICRgkW1WVsoVlCvQJHarOFiO1SIn4Q4izToTxVSVF77EFVbIt7VndWByVGWKlClQrVsAQhCbAEIQpAIQhVbAIQhLAIuhCmwSNVa6qhWRBN0/smATVLnO0jaXa8Vz1rTVDoJLguAIscOqiXAN6gta+TpObc95SSZljD2GTfRuJN7XsfBLLPHsWYIRdC0sqCEKWNDnWLg0czeykkhWAIKqrNdY5oyC8os8qi2Dg4FxGQy1WTiMRtoqEkKRzUAXUkqYkMFBUqpVyEQrNcQdVVCpaZY1IBF2+0LPipY6xQ4Z5IvQAOPNWvdUsgXCkgvkouFFyoUiiQbG4WznF0emQ7Vii6q+SSQoRdF1YqQVCChQyQQhChEkoUKUugWBUqim6tZWiyjNGJF0BF7Kb9iLouhNkZqWktIItkououmwNJJXyuu91ys1CFGy4AIQhRySCEIVgCEIVWAQhCIAhClVYIRZSoUoBZSoQpoAhCLWVgF0KbKFVsAhb0lHNWSYIACbgWLgNe9eopfJWGCn3tY58kjLuLIza45LNzoHkLEaiyhM1VSyV5ENPHDHc2AF3W7SUupTYBCEKyYBCsGOtfCVIicdRZWtAtGMTSLqwY0dpUZMFhqp0bclVJIksLAe1UQ51yq3V1sVZJKqhCq2AQhCgkApUIQE3RiUJiKhq5xeKmleLXu1hKnURRhdF12KTyY2hUi7gyHskJBPgFFX5NbSpj0YhOOcRuo1oUcdSmHbOrWetRzj/APWVlJBNELyRPYNLuaQmokooQnaDZdVXlwhYRYXBc02PtRugJIXcPkptMRl2GIkfkxZn+imLyU2m57BJG1jSekcYNgqakDhIXqHeRs28IbVNwcCWZrKp8j6yNrTBLHKfzA9G3zTUgecQu7T+Sm0JQTLu4baBxuT4LGXya2pG4BsAk7WPH9VOpA5KF2meSu03W6DG3F+k7Q8slDPJfaj5nRmNjABk9zuifBTqXsHGQu+fI/aIjuHwl9/VBOnfZLSeTO1oz/8Aa4hzD2/NNS9g5KLpmq2dWUYvUU72C176geCVU2AQhBFksEKUISwCF2vsvtD/AET/AM/+lX7MbR6sXvqNQOOhdlvkvtEmx3Te0vTsHkk7PzipAyy3Y+aageZQvXReSVO2S8lS97Lerht8U0zyZ2Ywglj326zzn4KNSB4dC+hxbL2bA8Ojo47jQ6/zTLI6Vos2GNg7GgKNYPmzIpJDaNjn/wC0XW79nVrLYqSbMXyYSvooEQ0b8EDANIz7VGsHzU004NjBJ7hUMglfII2RPc8/lDc19Lw34AKN006gHvVlMHzaGB0szYsTYy42u82AXZHkpVkXE0Hx+S9fJSQTC00LJANMTQVcMDbBosBwRzB4ceTO0yf8Jg7cYVX+Tu1I32bT478WuFl7wNKtpxVXNg8KNiV7Y3t9GuxHR28Bt8U7s3YL4JT6QoXztuLFlnD29IH4FesxFG8LeKq22DKLZlHHUsnZSRiRosCG2stq8gU8hDxH0D0+rlqjfOPFZzMZOwsmaHtOocLgqlA+YyPfJI58ji95Obibkqq93UeTWzJ7kRuhPON1vgbhIS+R0Z/wat4/3MBW2pA8s0t4tC0Ewb6rWj2LtHyQrQ+wngwc7m/hZQ7yRrQThngI7SR/RLQOMahx4qu8vqSvRw+SBsDPVZ8Qxv8AUrpUvk1QwZmMynnJmmpEnkKWlqKyQMp4S49Y6D2rox+TNfLYyPijHa65+C9i2kbbU9wWzKdo4X71Gsg85D5IUxaN5PM53EtsB/Ip2n8laGGQP3b5CMwHuuF3mADgtAVRzYOA7yR2c833bm9geVI8kNmj/Lcf+ZXdfIGa3Kw3zsVwfYq6mDmfZbZwjDPNmkDjiN/FYu8ktnnSJze6QrvMnvk4H2LVNTB56LyT2fGQTDjt1nlOx7EoWBwFLCA8AOGEWK6iE1MHMp9hUFLOZoadjX2tzXQay2tldSouwZPiDhyUCMNGo8FqiyAWkw29UeCWfCJrtcwObycLro4RyVLW/IVKdA5kewdm48Zo4i4m/q5eC6jY2tFgFXHbRhUCV1/VUN2DQhvJThHJZY5To1XZjPrAAIC1gjCOSlQXAalARhHJGAckF4AzUbw9QoC1giwVTK0ZE58goEoOgQGiCAeCxM5HAD2qWTNdxsoBJiYdQFR9LA9ha+Jjmu1BaCCtN40cVUzs7VIObV+T2zKiOxpI2HrRjCfguTU+SeyoGF8tbJCObntsPgvRyStLcjn2leW2nsSevrXPkrgYSSWjDm3ssrxv2Dzm0qWnpJ93T1YqRa5c1tgPjmlF6M+SoAyrgT/+L/tYyeS1Ta8U8b+8Fq1TQPUFp4Bylu8bo0+1cX7f7L/bVfut+pNweVdLO0ObRVTWnQuDR/5LJW+A3XJ0C+Qaj4KWyZaZrnzeVNNE3F5nVPH8Aaf/ACSX2+2X+1qvdb9SNtchO+Dv7zmCrA30B8F54+X2zMr0tV7rfmgeX+yx/wCmqvdb801ok9FY8ipsV537wNmftqv3W/Uj7wNl/tqr3W/UmtA9HYowu5Lzn3gbL/bVXut+pH3gbL/a1Xut+pNQPSBhvorgFeX+8DZn7aq91v1KfvA2Z+2qvdb9SjUD1AB5IsQvLfeBs39tVe636kfeBsz9tVe636k1A9TmoK8v9v8AZn7aq9xv1Kv2+2b+hVe436k1IHqbIw3Xlvt9s79Gq9xv1KPt9s/9Kr9xv1KLQPVYEbsry32+2f8ApVfuN+pSPL/Z/wCjVe436ksHqhHzU7vvXlfvA2d+hVe436kfeDs/9Cq9xv1JYo9VuzzVxGLZryf3hbO/Qqvcb9SPvC2d+3qvcb9SixR67djkpDAvIfeFs79vVe436lP3hbN/b1Xut+pLFHrw1ThC8f8AeHs79vVe636kfeHs79vVe636ksUexsEWXjvvD2d+3qvdb9SPvD2d+3qvdb9SCj2VkWXjvvE2d+3qvcb9Sj7xNn/t6r3G/Ugo9lZSvGfeHs/9Cq9xv1I+8PZ/6NV7jfqUWKPZqV4v7w9n/o1XuN+pR94Wz/0av3G/Ugo9qheK+8LZ/wClV+436lH3g7P/AEqz3W/UpFHtkLxP3gbO/SrPdb9SPt/s39Gs91v1KBR7a6jGF4n7fbM/Qq/db9SPt7sv9Cr91v1JYo9oZRy+IVd+OzxXjPt7sv8AQq/cb9SPt7sv9Cr9xv1IKPY78nQhG9PW8AvHfb3Zf6FX7jfqR9vdmfoVfut+pBR68yX1Lj8FGMcG+JXkft7sz9Cr91v1KPt5sz9Cr9xv1IKPW7w8LeCkyPI9YryP282Z+hV+436kfbzZn6FX7jfqQUequgleV+3mzP0Kv3G/Uo+3ezP0Kv3G/Ugo9TdVJK8z9u9l/oVfuN+pSPL7Zg0p6r3G/UgPSG5QGF+guvNHy82Yf8iq9jG/UpHl9s4f5NX7jfqU2D0hpnezsVPN3XyGXcuB94Gzv0Kr3G/Ug/8AxA2YdaaqP/Bv1KbB23xuvYiyBGbaFcT7fbK/a1PuN+pH2+2V+0qfcb9SageP2JRNlJqJBcNNmg8+a9G4xss0s/KDiGuYuqeR5pGUdq1rDG9pb0tQS7ULv0rNnvqahkzoHR+ox2WQA9YctQuiElCPBjKDlLk4EjC22eJpzBHFcraVDTNJq5QbN9ZjfzHgvVsZTS7NEGKGKUG2LE12Ml2XaP5JHyqbQu2UJaR0Y6BY9jTnkcjZRNuao1gseLfl/wDw8JLIZZC8gC/AaAclRCFymjd7gpaC5wA1JsoUtGJwFwLm1zoEIPWzeTGynR1tNR180tfRU+/kOEbp2VyAf+1Z3khRBrqEVk3pdtL5yW4Ruv8Abzumq1myKbYj6LZG2qWBjoyZzhLpKggaX4DsTLtr7K89f5QivjLnUW5FJb8THy7kBy6byToZG0tFNWTs2rVU3nDGBo3beIaeN8j4LOj8l6JmzKefaU1ayWpYZAaeEvZC3gX2BOa6tNtPZUlZQbfl2hGySko90+l/OXgEZdnSK02bt6lnptlVT9sNpGUMZZU0pveU2sLDigPn4iL6gQxHeFzsLSPzZ2Cfk2W2Xyi9F0chcDPuQ93O9ie7VX2dU032gfXPDY4Y3SVDGOyuRcsaO29lhsavFDtulrZrubHKHPOptxKA7W0/JugbQ1smyqqommoJmwzskaLOJNrtt2/yV9veTuytk0s9n7SM7LBrnQ/hOdyxWTtVWbL2bTbTfBtNlQ/adUyQCEXdEwPxEm/HM/BWr9o0tNsrau9256U89Y1sERN3MPMjRvw0QHkdlUbK2rc2ZzmwxxPlkc3UNa0n+dh7Uz5O7Jj2rUzmpldDS00LppntFzYcB2/JZUc0dNsevdjG/nLIWtB6QZfE493RaPanvJOtpoJK+jrJhBFXUzoRK7Rjjpfs1QD8fknR1VTRz0tXN6NqIHzuc9o3jQywcMsr5j4rmbc2RSUtBR7S2bNNLR1OJo3wAe1wOht/eS9DBtOh2dNsjZtPtaMCljl3lQGY43Oeb4T2a/BIeWO1oKjZ9Ds+GemnfE50kjqVmGJvINHddAeSQhCAF2m7O2U6S7toiOMO0viJHPQWvllnZcVdDofwoDSeg2fHCXs2kHvs6zAziBpr7FtLs7ZBF4tplvSzxDFll3dqV6H8KnofwoDcbN2ZjAO1W2PHB3569yiSh2YyqDI67exuDiM8FiCNXWPC504dqzGD+FXbg/hQEjZuzDG0+lBfV3Q4W4D+9exUkodmsnjA2jvI8QxnBbo2JNtc8re0LVu7/hWrd3/CgMptm7LbvHM2pdrG3DcNy7Lh7VJ2XsoAf/Vm5Nu44NTnoL9yZbuv4PgtWbr+D4IDmt2bQF8IbtASl8mEsaMJta9796IKHZkriH126BsWucb2yGRFueLusOa7LNz/AKfwW7Nx/p/BAecNJs0wxltY4PdI1rr52bgBJt/uuFuzZmyi9zTtYW/K7BbPLt/u/YV6Nnm/+l8Ewzzf/S+CA8YKGgxSYtoDCxgcCGZuOeWvYPFbw7N2c+SZorTLhAwFpDL5XORvcdy9qzzb/S+Cbh80yvufggPkyF9nh8z/AND4JxvmVv8A0/8A/KE0fDFtSMikqGsndhYb53tnbLPO2ds19P8ALvzb7LVG63OLGy2G1/WC+XU9t82+iEHVZs3ZZaS/ajWk3s0C+HvOV/ALN1Bs5ksY9ICVpeGusMNhYm98+P8ANZdD+FWGC/5VKVgY9G7KdhcNphgvYtIvb25eNlnLQbMjbA5u0ceJ4bI0NsQM+l2cP7yW9Pu754F1qfc2F938FZxpGE82l8HEbs7ZjmXO0WxvJ9W+INzzzsL5d3tWU9Ds5kMj49pY3NIAbu/W58V7Kn83uL7r4LSo82sbbr4Lz8nV6JVpN8X/ACHjnbP2YST6REYxYQPXNud7Dw4I9G7Mbm7aoIzyEeZ07f79i7Nduc7bv2WXMdu/4Vrjz6/B3y6Ko6tRQbM2V0ydqi1uj0dDlrz4qkWy6CSobE2vxgg4nAAYLOAv25En2KX4LflV6fd3zwrqjGzmliryUk2XsyMkHaoJ6NsLL3vx1SO0aaCmfE2nm3zXMuX6AnERl2ZL01Lucr7v4Lu7P82uL7n22VtH8ldB8xQvtTPM7f5HwUO8zt/kfBRoGj+T4shfYJfNeG5+CTf5t/pfBT2/5No9Pq8nytC+j1Hm3DdfBeS8pcG9gwYdHaexVcaGTp9EdVlNh1gY90Epycbgngu+xxjc17TYg3BXirm1r5FNwbUqoG4Q/E0aB4utceWlUjgnB8x5PVNeN7jOWd7NC4m3a5r2imjN87v7OxIzbVq5W4cYYD1BZJK2TMmqiVhiads6dBsd9bQTVQmazBjwswkl2FuJ3dkR/YTv2Qr99NHjiAYXBpLgMRDrC/K+o7lxYqqogjfHDPLGyTJ7WPIDu8cVqNqbQaQRXVIIvpM7jmePFcxuPP8AJushpo56gtjEj42NGp6XPuy8UzWeR1dAG7qSOa5eNcOhAbrxde64r6+sfG2N9XO5jLYWmQkNtpZWO0q83vW1OYIP4rtDa417B4IDrN8ka9xi6UfSsJLOB3d3Ftu0ix8FnJ5LV4aHxmJ0ZAdiLw2wLQ4kjkLrm+k6/wDfVOgH+K7QacVaDa1fTyskZVyks0DnFw8CgG4PJvaNRNPFGyMuglET+mLYiQMvFRUeT9VS7PmrJ3xhkeEtwuDt4HWsR2ZhKO2pXmaWUVczHzPxvwPLQ53OwWbq2qdDuXVMxiy6BkOHK1suyw8EB1anyV2hAQGhrrQCZ1zhtrduepFlb7JbRsR+EHNLgQXgCwDTcHj63wXKG0K1ocBWVADyS4CV2d9b58VJ2lXOJJrakk63ldn8eweCA6zfJGvfEzA5hmLi0sJyFnObr3t+Kzm8lq1kTZI3xygtxHO35cVhfU2v4Lmt2nXsN211S08xK7v5qPSFbgLPPKjCW4SN66xGltdEA6dgzQ1skFXNHE2OIyvez8SzQ7AbAanFl7CnH+SczGSDzuN0rGucI2t1sX2157sriNratswmbUzCUXs8SHELkk595J9qPPKrP/5mbO4PTOd73/8Ac7xPNAO1ewK6jpZamVsZiidhc5rwc8v5EgLlpiWurJ2OZNVTyNeQXNfISDbml0AIQhAM0klIxrhUwukJc0gg6C+Y14rCUsdK8xtwsLjhHIKqEA5HLRCmDZIHmbA4YgcsRPROvBJoQgGZpKV1OBFEWTYgSeFsIuNedysYXMbMx0rcbA4Ym8wqIQG1S6Bxj83Y5gEYD8X5ncSppn0zWy+cRueSOhh4Hx+awQgNKh0T6iR0DDHEXEtaTcgcrpimloWQgVFO58lzcg8PFJoQAnJJaE0payB4nwtAdfK49Y68UmhAWYWiRpe0uaCLgG1x3rerfSPDPNYnMOJxdi5E9Ea8AlkIDWndC17t/G57SwgYTazrZHttyU1b4H1DnU0ZjiNsLSbkZZ/FYoQDdLLRMjAqYHyOEgccLrXby/vxSh1yQhAOmWg82winfvsFi4uyxc9f7+KIaiijpmtfSbybPE4kgcbaHuSSEALoQVGzmU7WzUjnyWOJwcRztbPuXPQgBP7/AGf5kGeavNRhIL8Rtexz152SCEALoCfZvmQYaV/nGCxfc2xWOevOy56EALo7/ZnmWDzV/nGC2O+WK2uq5yEAJ+So2f5lgjpHecYbF7ibXyztfvSCEALoyz7LNKWx0kgmw2D8RtfLPVc5CAE9VT7PfDhp6VzJLesSdcuFz2+KRQgBdCqn2a+nc2npXslys4k217+9c9CAltg4XFxfNP1c+zX05bTUr45bizif+yuehACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhAf//Z\n"
+            "text/html": [
+              " <iframe width=\"970\" height=\"576\" src=\"https://www.youtube.com/embed/x1SgmFa0r04?si=5U0vy4jHix7A6cqM\" title=\"YouTube video player\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe> "
+            ]
           },
-          "metadata": {
-            "tags": []
-          }
+          "metadata": {}
         }
       ]
     },
@@ -1998,7 +1975,7 @@
         "<br>\n",
         "\n",
         "## 5. Övningar med CO$_2$-data från mätstationen Hyltemossa\n",
-        "Här kommer du att få lära dig mer om koldioxidets kretslopp genom att använda ett interaktivt diagram som visar dagliga samt årliga förändringar i koldioxidkoncentrationen i luften. Innan du fortsätter med övningarna är det viktigt att du får lite mer information om mätstationer. \n",
+        "Här kommer du att få lära dig mer om koldioxidets kretslopp genom att använda ett interaktivt diagram som visar dagliga samt årliga förändringar i koldioxidkoncentrationen i luften. Innan du fortsätter med övningarna är det viktigt att du får lite mer information om mätstationer.\n",
         "\n",
         "\n",
         "\n",
@@ -2091,7 +2068,7 @@
         "\n",
         "#Funktion som skapar en interaktiv plott från en pandas dataframe med co2-data i given färg:\n",
         "def plott(df_L2, color):\n",
-        "    \n",
+        "\n",
         "    #Importera moduler:\n",
         "    from datetime import datetime\n",
         "    from bokeh.plotting import figure\n",
@@ -2108,7 +2085,7 @@
         "    #Skapa ett figur-objekt:\n",
         "    p = figure(width=900,\n",
         "               height=500,\n",
-        "               x_axis_label='Tid (UTC)', \n",
+        "               x_axis_label='Tid (UTC)',\n",
         "               y_axis_label='CO2'.translate(SUB)+' (' +'\\u03BC'+ 'mol.mol-1'.translate(SUP) + ')',\n",
         "               x_axis_type='datetime',\n",
         "               title = 'Koldioxidkoncentration (Hyltemossa, Sverige, '+str(df_L2.SamplingHeight.iloc[0])+'m)' ,\n",
@@ -2116,7 +2093,7 @@
         "\n",
         "    #Skapa en cirkel-glyph:\n",
         "    r0 = p.circle(x='DateTime', y='co2', source=source, radius=.12, color=color)\n",
-        "    \n",
+        "\n",
         "    #Skapa en linje-glyph:\n",
         "    r1 = p.line(x='DateTime', y='co2', source=source,\n",
         "                line_width=1, color=color)\n",
@@ -2127,11 +2104,11 @@
         "        ('CO2'.translate(SUB),'@co2{0.f}'),\n",
         "        ],\n",
         "        formatters={\n",
-        "            '@DateTime'      : 'datetime', \n",
+        "            '@DateTime'      : 'datetime',\n",
         "        },\n",
         "        # visa ett tooltip när musen är i lodrätt-linje med motsvarande glyph\n",
         "        mode='vline'\n",
-        "        ))  \n",
+        "        ))\n",
         "\n",
         "    #Definiera formatteringsattribut för plottens titel:\n",
         "    p.title.align = 'center'\n",
@@ -2160,7 +2137,7 @@
         "\n",
         "    #Definiera vart resultatet ska visas:\n",
         "    output_notebook()\n",
-        "    \n",
+        "\n",
         "    #Visa plott:\n",
         "    show(p)\n",
         "\n",
@@ -2635,7 +2612,7 @@
         "              create_coding_quiz_question_dropdown('Övning 3', ['höst-vinter', 'vinter-vår', 'vår-sommar', 'sommar-höst'], 'sommar-höst'),\n",
         "              create_coding_quiz_question_dropdown('Övning 4', ['fotosyntes', 'respiration', 'biltrafik', 'skogsbrand'], 'fotosyntes')]))"
       ],
-      "execution_count": 2,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2677,7 +2654,7 @@
         "\n",
         "###### Figure credits\n",
         "<font size=\"0.7\">CO$_2$-icon made by Freepik from www.flaticon.com<br>Carbon Cycle figure created by Karolina Pantazatou (ICOS Carbon Portal), inspired by figure created by Peter Reid (ScottishCentre for CarbonStorage) https://www.icos-cp.eu/ <br>Map of ICOS station nertwork 2020 created by Karolina Pantazatou (ICOS Carbon Portal) https://www.icos-cp.eu/<br>Photos of ICOS Hyltemossa station, courtesy of Tobias Biermann tobias.biermann@cec.lu.se</font>\n",
-        " "
+        ""
       ]
     }
   ]


### PR DESCRIPTION
Fix Youtube embedding in kolcykeln_enkel/kolcykeln_htm.ipynb.

Note that the HTML code for the embedded Youtube video starts with a space. This to surpress a warning about using the IFrame class instead, which I couldn't get to work. 